### PR TITLE
bugfix for non-english windows installations

### DIFF
--- a/django_windows_tools/management/commands/winfcgi_install.py
+++ b/django_windows_tools/management/commands/winfcgi_install.py
@@ -50,8 +50,10 @@ def set_file_readable(filename):
     import win32security
     import ntsecuritycon as con
 
-    users, domain, type = win32security.LookupAccountName ("", "Users")
-    admins, domain, type = win32security.LookupAccountName ("", "Administrators")
+    WinBuiltinUsersSid=27 # not exported by win32security. according to WELL_KNOWN_SID_TYPE enumeration from http://msdn.microsoft.com/en-us/library/windows/desktop/aa379650%28v=vs.85%29.aspx
+    users=win32security.CreateWellKnownSid(WinBuiltinUsersSid)
+    WinBuiltinAdministratorsSid=26 # not exported by win32security. according to WELL_KNOWN_SID_TYPE enumeration from http://msdn.microsoft.com/en-us/library/windows/desktop/aa379650%28v=vs.85%29.aspx
+    admins=win32security.CreateWellKnownSid(WinBuiltinAdministratorsSid)
     user, domain, type = win32security.LookupAccountName ("", win32api.GetUserName ())
 
     sd = win32security.GetFileSecurity (filename, win32security.DACL_SECURITY_INFORMATION)


### PR DESCRIPTION
"manage.py winfcgi_install" fails on non-english localization, because the users group and the admins group have different (localized) names there.

```
import win32security

def users_group():

    # THE BUG

    # choose language by commenting
    #users_name='Users' # english
    users_name='Benutzer' # german

    explicit_users, domain, type = win32security.LookupAccountName ("", users_name)
    print 'the sid of the user group is %s'%win32security.ConvertSidToStringSid(explicit_users)

    # THE FIX

    WinBuiltinUsersSid=27 # not exported by win32security. according to WELL_KNOWN_SID_TYPE enumeration from http://msdn.microsoft.com/en-us/library/windows/desktop/aa379650%28v=vs.85%29.aspx
    well_known_users=win32security.CreateWellKnownSid(WinBuiltinUsersSid)
    print 'the sid of the user group is %s'%win32security.ConvertSidToStringSid(well_known_users)

    # PLAY SAFE

    assert(win32security.ConvertSidToStringSid(explicit_users)==win32security.ConvertSidToStringSid(well_known_users))

def admins_group():

    # THE BUG

    # choose language by commenting
    #admins_name='Administrators' # english
    admins_name='Administratoren' # german

    explicit_admins, domain, type = win32security.LookupAccountName ("", admins_name)
    print 'the sid of the admins group is %s'%win32security.ConvertSidToStringSid(explicit_admins)

    # THE FIX

    WinBuiltinAdministratorsSid=26 # not exported by win32security. according to WELL_KNOWN_SID_TYPE enumeration from http://msdn.microsoft.com/en-us/library/windows/desktop/aa379650%28v=vs.85%29.aspx
    well_known_admins=win32security.CreateWellKnownSid(WinBuiltinAdministratorsSid)
    print 'the sid of the admins group is %s'%win32security.ConvertSidToStringSid(well_known_admins)

    # PLAY SAFE

    assert(win32security.ConvertSidToStringSid(explicit_admins)==win32security.ConvertSidToStringSid(well_known_admins))

if __name__=='__main__':
    users_group()
    admins_group()
```
