### PR TITLE
python 3 compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pip-log.txt
 
 #sphinx
 _build
+
+#pycharm
+.idea/

--- a/django_windows_tools/management/commands/winfcgi.py
+++ b/django_windows_tools/management/commands/winfcgi.py
@@ -345,14 +345,14 @@ def decode_pair(s, pos=0):
     The number of bytes decoded as well as the name/value pair
     are returned.
     """
-    nameLength = s[pos]
+    nameLength = ord(s[pos]) if type(s) is str else s[pos]
     if nameLength & 128:
         nameLength = struct.unpack('!L', s[pos:pos + 4])[0] & 0x7fffffff
         pos += 4
     else:
         pos += 1
 
-    valueLength = s[pos]
+    valueLength = ord(s[pos]) if type(s) is str else s[pos]
     if valueLength & 128:
         valueLength = struct.unpack('!L', s[pos:pos + 4])[0] & 0x7fffffff
         pos += 4

--- a/django_windows_tools/management/commands/winfcgi.py
+++ b/django_windows_tools/management/commands/winfcgi.py
@@ -902,7 +902,7 @@ class FCGIServer(object):
                         if data:
                             write(make_bytes(data))
                     if not headers_sent:
-                        write('')  # in case body was empty
+                        write(b'')  # in case body was empty
                 finally:
                     # if hasattr(result, 'close'):
                     #    result.close()

--- a/django_windows_tools/management/commands/winfcgi_install.py
+++ b/django_windows_tools/management/commands/winfcgi_install.py
@@ -26,7 +26,7 @@
 # OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 # SUCH DAMAGE.
 #
-
+from __future__ import print_function
 __author__ = 'Antoine Martin <antoine@openance.com>'
 
 import os
@@ -197,7 +197,7 @@ directory !''')
             
         # create web.config
         if not options['skip_config']:
-            print "Creating web.config"
+            print("Creating web.config")
             template = get_template('windows_tools/iis/web.config')
             file = open(self.web_config, 'w')
             file.write(template.render(Context(self.__dict__)))
@@ -209,27 +209,27 @@ directory !''')
             
         # create FastCGI application
         if not options['skip_fastcgi']:
-            print "Creating FastCGI application"
+            print("Creating FastCGI application")
             if not self.create_fastcgi_section(options):
                 raise CommandError('The FastCGI application creation has failed with the following message :\n%s' % self.last_command_error)
             
         # Create sites
         if not options['skip_site']:
             site_name = options['site_name']
-            print "Creating application pool with name %s"  % site_name
+            print("Creating application pool with name %s"  % site_name)
             if not self.run_config_command('add', 'apppool', '/name:%s' % site_name):
                 raise CommandError('The Application Pool creation has failed with the following message :\n%s' % self.last_command_error)
                 
-            print "Creating the site"
+            print("Creating the site")
             if not self.run_config_command('add', 'site', '/name:%s' % site_name, '/bindings:%s' % options['binding'], '/physicalPath:%s' % self.install_dir):
                 raise CommandError('The site creation has failed with the following message :\n%s' % self.last_command_error)
             
-            print "Adding the site to the application pool"
+            print("Adding the site to the application pool")
             if not self.run_config_command('set', 'app', '%s/' % site_name, '/applicationPool:%s' % site_name):
                 raise CommandError('Adding the site to the application pool has failed with the following message :\n%s' % self.last_command_error)
             
             if static_is_local and static_needs_virtual_dir:
-                print "Creating virtual directory for [%s] in [%s]" % (static_dir, static_url)
+                print("Creating virtual directory for [%s] in [%s]" % (static_dir, static_url))
                 if not self.run_config_command('add', 'vdir', '/app.name:%s/' % site_name, '/path:/%s' % static_name, '/physicalPath:%s' % static_dir):
                     raise CommandError('Adding the static virtual directory has failed with the following message :\n%s' % self.last_command_error)
                 
@@ -239,21 +239,21 @@ directory !''')
             raise CommandError('A web site configuration does not exists in [%s] !' % self.install_dir)
 
         if not options['skip_config']:
-            print "Removing site configuration"
+            print("Removing site configuration")
             os.remove(self.web_config)
         
         if not options['skip_site']:
             site_name = options['site_name']
-            print "Removing The site"
+            print("Removing The site")
             if not self.run_config_command('delete', 'site', site_name):
                 raise CommandError('Removing the site has failed with the following message :\n%s' % self.last_command_error)
 
-            print "Removing The application pool"
+            print("Removing The application pool")
             if not self.run_config_command('delete', 'apppool', site_name):
                 raise CommandError('Removing the site has failed with the following message :\n%s' % self.last_command_error)
 
         if not options['skip_fastcgi']:
-            print "Removing FastCGI application"
+            print("Removing FastCGI application")
             if not self.delete_fastcgi_section():
                 raise CommandError('The FastCGI application removal has failed')
 
@@ -273,7 +273,7 @@ Please run it with the manage.py of the root directory of your project.
             
         self.install_dir = os.path.normcase(os.path.abspath(self.install_dir))
                 
-        print 'Using installation directory %s' % self.install_dir
+        print('Using installation directory %s' % self.install_dir)
         
         self.web_config = os.path.join(self.install_dir, 'web.config')
         
@@ -293,5 +293,5 @@ Please run it with the manage.py of the root directory of your project.
         
 
 if __name__ == '__main__':
-    print 'This is supposed to be run as a django management command'
+    print('This is supposed to be run as a django management command')
         

--- a/django_windows_tools/management/commands/winservice_install.py
+++ b/django_windows_tools/management/commands/winservice_install.py
@@ -27,6 +27,7 @@
 # SUCH DAMAGE.
 #
 
+from __future__ import print_function
 __author__ = 'Antoine Martin <antoine@openance.com>'
 
 import os
@@ -136,7 +137,7 @@ class Command(BaseCommand):
         full_path = os.path.join(self.project_dir, filename)
         if os.path.exists(full_path) and not overwrite:
             raise CommandError('The file %s already exists !' % full_path)
-        print "Creating %s " % full_path
+        print("Creating %s " % full_path)
         template = get_template(template)
         file = open(full_path, 'w')
         file.write(template.render(Context(kwargs)))
@@ -185,5 +186,5 @@ Please run it with the manage.py of the root directory of your project.
             
 
 if __name__ == '__main__':
-    print 'This is supposed to be run as a django management command'
+    print('This is supposed to be run as a django management command')
         

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
-#Django==1.4
+django>=1.4
 pypiwin32
+future

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 #Django==1.4
-pywin32
+pypiwin32


### PR DESCRIPTION
Hello.  Thanks for django-windows-tools - it's been really useful.  We've upgraded our systems to python 3 and had to make some changes to the module to get that working.  Hopefully this is useful for you!

There are a few things we're still not sure about:
* If you can find some supporting evidence which suggests that FCGI parameter keywords and values are *always* pure ASCII then some of the encoding work can be removed.
* We've re-enabled the cgitb feature but have observed what look like exception loops in some circumstances which end up with an FCGI timeout.  We've mitigated this by ensuring that the backtrace is written to the fcgi log file but if the timeout could be fixed that would be better (obviously).  It would be a shame to lose the cgitb.
* The changes we've made appear to be backwards compatible to python 2.7.  I'm not sure how much further back they will work.
* When the FCGIServer's run method opens stdin and stdout (or possibly stdin and stdin again??) We're not certain whether the call to msvcrt.setmode is still required.

Let us know if you'd like us to do more work on this feature.

Kind regards,

Chris Eveleigh
*Abide Financial*