### PR TITLE
Fixed wrong I/O stream fileno

### DIFF
--- a/django_windows_tools/management/commands/winfcgi.py
+++ b/django_windows_tools/management/commands/winfcgi.py
@@ -797,7 +797,7 @@ class FCGIServer(object):
     def run(self):
         msvcrt.setmode(sys.stdin.fileno(), os.O_BINARY)
         stdin = os.fdopen(sys.stdin.fileno(), 'rb', 0)
-        stdout = os.fdopen(sys.stdin.fileno(), 'wb', 0)
+        stdout = os.fdopen(sys.stdout.fileno(), 'wb', 0)
 
         conn = Connection(stdin, stdout, self)
         try:


### PR DESCRIPTION
It's not guaranteed that `sys.stdin.fileno() == sys.stdout.fileno()`. 

For example, when I launch `python manage.py winfcgi` command from PowerShell for debugging purposes, I get `ValueError: Cannot open console input buffer for writing` precisely because `sys.stdin.fileno() != sys.stdout.fileno()`.